### PR TITLE
fix: issue 1: cannot construct ArrayStateParser

### DIFF
--- a/src/stateparser.mjs
+++ b/src/stateparser.mjs
@@ -178,6 +178,7 @@ export class ArrayParseResult {
         const {startIndex=0, endIndex = undefined, errorIndex = undefined, createNewResult=false, 
             /** @type {ELEMENT[]} */ result=[]} = param;
         const {currentIndex=startIndex, isEnd = false, isError = false} = param;
+        const {isComplete = false} = param;
 
         /**
          * The start index of the parse result.


### PR DESCRIPTION
Inserted the missing property initialization from
parameters with default value.

modified:   src/stateparser.mjs
- fix: ArrayStateParser constructor initializes
the isComplete from parameters.