### PR TITLE
fix: issue-3

### DIFF
--- a/src/stateparser.mjs
+++ b/src/stateparser.mjs
@@ -206,8 +206,8 @@ export class IterableIndexingParseResult {
      * @param {IterableParseResultIndexing<ELEMENT, RESULT>} [params] The initial state.
      */
     constructor(params = {}) {
-        const { startIndex = 0, endIndex = undefined, errorIndex = undefined } = param;
-        const { currentIndex = startIndex } = param;
+        const { startIndex = 0, endIndex = undefined, errorIndex = undefined } = params;
+        const { currentIndex = startIndex } = params;
 
         /**
          * The start index of the parse result.


### PR DESCRIPTION
The new class IterableIndexingParseResult constructor had typo referring to the construction parameters with param instead of params.

modified:   src/stateparser.mjs
- fix: issue-3
  - class IterableIndexingParseResult
    - fix: Corrected the typo on the parameter handling by replacing
    param with params.